### PR TITLE
align!

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [garden "1.3.3"]
                  [cheshire "5.8.0"]
                  [clj-http "3.7.0"]
-                 [org.clojure/tools.cli "0.3.5"]]
+                 [org.clojure/tools.cli "0.3.5"]
+                 [com.climate/claypoole "1.1.4"]]
   :main autochrome.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/autochrome/align.clj
+++ b/src/autochrome/align.clj
@@ -33,7 +33,7 @@
 
         (empty? targets)
         (concat diffs
-                (for [s sources]
+                (for [s (cons the-source sources)]
                   [s nil (doto (IdentityHashMap.) (.put s :deleted))]))
 
         :else

--- a/src/autochrome/align.clj
+++ b/src/autochrome/align.clj
@@ -1,0 +1,49 @@
+(ns autochrome.align
+  (:require [autochrome.diff :as diff]
+            [autochrome.tree :as tree]
+            [autochrome.parse :as parse])
+  (:import [java.util IdentityHashMap Map]))
+
+(defn get-diffs
+  [source-forms target-forms]
+  (let [prep (diff/diff-prep source-forms target-forms)
+        ^IdentityHashMap hashes (:hashes prep)
+        ^IdentityHashMap sizes (:sizes prep)
+
+        hash->source-form (zipmap (map #(.get hashes %) source-forms) source-forms)
+        ^IdentityHashMap matched-forms (IdentityHashMap.)
+        unmatched? #(not (.containsKey matched-forms %))]
+
+    (doseq [tf target-forms]
+      (when-let [sf (hash->source-form (.get hashes tf))]
+        (.put matched-forms tf :matched)
+        (.put matched-forms sf :matched)))
+
+    (loop [diffs []
+           [the-source & sources] (filterv unmatched? source-forms)
+           targets (filterv unmatched? target-forms)]
+      (cond
+        (and (nil? the-source) (empty? targets))
+        diffs
+
+        (nil? the-source)
+        (concat diffs
+                (for [t targets]
+                  [nil t (doto (IdentityHashMap.) (.put t :added))]))
+
+        (empty? targets)
+        (concat diffs
+                (for [s sources]
+                  [s nil (doto (IdentityHashMap.) (.put s :deleted))]))
+
+        :else
+        (let [goal (diff/dforms the-source (cons nil targets) hashes sizes)
+              the-target (diff/get-target goal)]
+          ;(println 'goal-cost (diff/get-cost goal) 'nstates (count @diff/explored-states) 'npopped @diff/npopped)
+          ;(println 'source (parse/render the-source))
+          ;(println 'target (parse/render the-target))
+          (.put matched-forms the-target :matched)
+          (recur
+            (conj diffs [the-source the-target (diff/diffstate->annotations goal)])
+            sources
+            (filter unmatched? targets)))))))

--- a/src/autochrome/components.clj
+++ b/src/autochrome/components.clj
@@ -106,12 +106,14 @@
       form-annotation? (dom/span {:className (str (name annotation))}))))
 
 (defn line-numbers
-  [{:keys [lines start-line linkbase] :as the-form}]
-  (for [i (range start-line (+ start-line lines))
-        :let [;; make up a unique id so the browser doesn't try to scroll
-              uid (str (.substring linkbase (- (count linkbase) 5)) i)]]
-    (cond->> (dom/div {} (str i))
-      linkbase (dom/a {:href (str linkbase i)}))))
+  [{:keys [lines start-line linkbase] :as the-form :or {linkbase "hahaha"}}]
+  (if-not (and lines start-line)
+    (println 'no-line-numbers (autochrome.parse/render the-form))
+    (for [i (range start-line (+ start-line lines))
+          :let [;; make up a unique id so the browser doesn't try to scroll
+                uid (str (.substring linkbase (- (count linkbase) 5)) i)]]
+      (cond->> (dom/div {} (str i))
+               linkbase (dom/a {:href (str linkbase i)})))))
 
 (defcomponent code
   [{:keys [lines start-line linkbase things annotation id] :as the-form} children]

--- a/src/autochrome/components.clj
+++ b/src/autochrome/components.clj
@@ -107,13 +107,9 @@
 
 (defn line-numbers
   [{:keys [lines start-line linkbase] :as the-form :or {linkbase "hahaha"}}]
-  (if-not (and lines start-line)
-    (println 'no-line-numbers (autochrome.parse/render the-form))
-    (for [i (range start-line (+ start-line lines))
-          :let [;; make up a unique id so the browser doesn't try to scroll
-                uid (str (.substring linkbase (- (count linkbase) 5)) i)]]
-      (cond->> (dom/div {} (str i))
-               linkbase (dom/a {:href (str linkbase i)})))))
+  (for [i (range start-line (+ start-line lines))]
+    (cond->> (dom/div {} (str i))
+             linkbase (dom/a {:href (str linkbase i)}))))
 
 (defcomponent code
   [{:keys [lines start-line linkbase things annotation id] :as the-form} children]

--- a/src/autochrome/core.clj
+++ b/src/autochrome/core.clj
@@ -32,3 +32,4 @@
       (when-not (:output options)
         (io/copy output-file *out*))))
   (shutdown-agents))
+

--- a/src/autochrome/core.clj
+++ b/src/autochrome/core.clj
@@ -11,13 +11,15 @@
 (def cli-options
   [[nil "--open" "If set, write HTML to a temp file and try to open it in a browser"]
    ["-t" "--token TOKEN" "github api bearer auth token e.g. username:123abcdef"]
-   ["-o" "--output FILE" "output filename"]])
+   ["-o" "--output FILE" "output filename"]
+   [nil "--clojure-only" "only show clojure diffs"]])
 
 (defn -main
   [& args]
   (let [{:keys [options arguments]} (cli/parse-opts args cli-options)
         [a b c] arguments
-        the-page (binding [github/*auth-token* (:token options)]
+        the-page (binding [github/*auth-token* (:token options)
+                           page/*clojure-only* (:clojure-only options)]
                    (cond
                      c (page/pull-request-diff a b (Integer/parseInt c))
                      b (page/local-diff a b)))

--- a/src/autochrome/core.clj
+++ b/src/autochrome/core.clj
@@ -12,14 +12,16 @@
   [[nil "--open" "If set, write HTML to a temp file and try to open it in a browser"]
    ["-t" "--token TOKEN" "github api bearer auth token e.g. username:123abcdef"]
    ["-o" "--output FILE" "output filename"]
-   [nil "--clojure-only" "only show clojure diffs"]])
+   [nil "--clojure-only" "only show clojure diffs"]
+   [nil "--git-dir PATH" "path to the git repo"]])
 
 (defn -main
   [& args]
   (let [{:keys [options arguments]} (cli/parse-opts args cli-options)
         [a b c] arguments
         the-page (binding [github/*auth-token* (:token options)
-                           page/*clojure-only* (:clojure-only options)]
+                           page/*clojure-only* (:clojure-only options)
+                           github/*git-dir* (or (:git-dir options) ".")]
                    (cond
                      c (page/pull-request-diff a b (Integer/parseInt c))
                      b (page/local-diff a b)))

--- a/src/autochrome/core.clj
+++ b/src/autochrome/core.clj
@@ -1,5 +1,6 @@
 (ns autochrome.core
-  (:require [autochrome.github :as github]
+  (:require [autochrome.diff :as diff]
+            [autochrome.github :as github]
             [autochrome.page :as page]
             [clojure.java.io :as io]
             [clojure.tools.cli :as cli])
@@ -23,6 +24,7 @@
         output-file (if (:output options)
                       (io/file (:output options))
                       (File/createTempFile "diff" ".html"))]
+    (binding [*out* *err*] (println 'processed @diff/nprocessed 'states))
     (if-not the-page
       (println "expected 2 or 3 args [treeA treeB] or [owner repo pr-id] ")
       (spit output-file the-page))
@@ -32,4 +34,3 @@
       (when-not (:output options)
         (io/copy output-file *out*))))
   (shutdown-agents))
-

--- a/src/autochrome/diff.clj
+++ b/src/autochrome/diff.clj
@@ -29,14 +29,14 @@
        (and (compare-vectors-by-identity (.-prevsources this) (.-prevsources that))
             (compare-vectors-by-identity (.-prevtargets this) (.-prevtargets that)))))))
 
-(deftype DiffState [cost sremain tremain source target context changes]
+(deftype DiffState [cost source target context changes origtarget]
   ;; `source` and `target` are seqs, and we are diffing their heads
   ;; `cost` is the sum of the size of all the added or deleted nodes in this diff
-  ;; `sremain` and `tremain` are the remaining sizes of the source/target form respectively
   ;; `context` is how we know 'where we are' in the source & target structures
   ;;   without context, we can't tell when we're finished, since all states
   ;;   where source=target=nil would be indistinguishable.
   ;; `changes` is a vector of [form change] where change is :added, :deleted etc
+  ;; `origtarget` is the whole target form we are diffing against
   Object
   (hashCode [this]
     (unchecked-add-int
@@ -53,82 +53,103 @@
     (let [^DiffState that that-obj]
       (- (.-cost this) (.-cost that)))))
 
+(defn get-cost
+  [^DiffState ds]
+  (.-cost ds))
+
+(defn get-target
+  [^DiffState ds]
+  (.-origtarget ds))
+
 ;; for difflog
 (def explored-states (atom []))
 (def state-info (atom {}))
+(def npopped (atom 0))
+
+(def ^:dynamic *max-cost* Long/MAX_VALUE)
+
+(defn diff-prep
+  [sources targets]
+  (let [hashes (IdentityHashMap.)
+        sizes (IdentityHashMap.)]
+    (doseq [f (concat sources targets)]
+      (tree/put-hashes hashes f)
+      (tree/put-sizes sizes f))
+    {:hashes hashes :sizes sizes}))
 
 (defn dforms
-  [source target]
-  (let [size-map (doto (IdentityHashMap.) (.put nil 0) (tree/put-sizes source) (tree/put-sizes target))
-        hashes (doto (IdentityHashMap.) (tree/put-hashes source) (tree/put-hashes target))
-        ;; use double the real size so that our hacks can't make the heuristic inadmissible
-        start-state (DiffState. 0 (* 2 (.get size-map source)) (* 2 (.get size-map target))
-                                (:contents source) (:contents target)
-                                (DiffContext. [] []) [])
-        real-cost (doto (HashMap.) (.put start-state 0))
-        pq (doto (PriorityQueue.) (.offer start-state))
-        explore (fn [ncost predstate sremain tremain nsource ntarget nctx changes]
-                  (let [ds (DiffState. (+ ncost (max sremain tremain)) sremain tremain nsource ntarget nctx changes)
-                        prev-cost (.get real-cost ds)]
-                    (swap! explored-states conj ds)
-                    (swap! state-info update (System/identityHashCode ds) assoc :pred (System/identityHashCode predstate))
-                    (when (or (nil? prev-cost) (< ncost prev-cost))
-                      (swap! state-info update (System/identityHashCode ds) update :attrib conj
-                             (if (nil? prev-cost) :best :better))
-                      (.put real-cost ds ncost)
-                      (.offer pq ds))))]
-    (reset! explored-states [start-state])
-    (reset! state-info {})
-    (loop []
-      (when-let [^DiffState c (.poll pq)]
-        (let [[shead & smore :as sforms] (.-source c)
-              [thead & tmore :as tforms] (.-target c)
-              cost (.get real-cost c)
-              sremain (.-sremain c)
-              tremain (.-tremain c)
-              ^DiffContext context (.-context c)
-              prevsources (.-prevsources context)
-              prevtargets (.-prevtargets context)]
-          (swap! state-info update (System/identityHashCode c) update :attrib conj :popped)
-          (if (and (nil? shead) (nil? thead) (empty? prevsources) (empty? prevtargets))
-            c
-            (let [ssize (.get size-map shead)
-                  tsize (.get size-map thead)]
-              ;; if we can match subtrees, don't bother doing anything else
-              (if (and shead thead (= (.get hashes shead) (.get hashes thead)))
-                (explore cost c (- sremain ssize) (- tremain tsize) smore tmore context (.-changes c))
-                (do
-                  (if shead
-                    ;; addition/deletion costs an extra point so that we prefer removing entire lists
-                    (explore (inc (+ cost ssize)) c (- sremain ssize) tremain smore tforms context (conj (.-changes c) [shead :deleted]))
-                    ;; if we are at the end of the source seq, pop back out if we can
-                    (when (not= 0 (count prevsources))
-                      (explore cost c sremain tremain (peek prevsources) tforms
-                               (DiffContext. (pop prevsources) prevtargets) (.-changes c))))
+  ([source targets]
+    (let [{:keys [hashes sizes]} (diff-prep [source] targets)]
+      (dforms source targets hashes sizes)))
+  ([source targets ^IdentityHashMap hashes ^IdentityHashMap sizes]
+   (let [real-cost (HashMap.)
+         pq (PriorityQueue.)
+         explore (fn [ncost ^DiffState predstate nsource ntarget nctx changes]
+                   (let [ds (DiffState. ncost nsource ntarget nctx changes (.-origtarget predstate))
+                         prev-cost (.get real-cost ds)]
+                     (swap! explored-states conj ds)
+                     (swap! state-info update (System/identityHashCode ds) assoc :pred (System/identityHashCode predstate))
+                     (when (and (or (nil? prev-cost) (< ncost prev-cost)))
+                       (swap! state-info update (System/identityHashCode ds) update :attrib conj
+                              (if (nil? prev-cost) :best :better))
+                       (.put real-cost ds ncost)
+                       (.offer pq ds))))]
+     (reset! explored-states [])
+     (reset! state-info {})
+     (reset! npopped 0)
+     (doseq [t targets
+             :let [start-state (DiffState. 0 (list source) (list t) (DiffContext. [] []) [] t)]]
+       (.offer pq start-state)
+       (.put real-cost start-state 0))
+     (loop []
+       (when-let [^DiffState c (.poll pq)]
+         (swap! npopped inc)
+         (let [[shead & smore :as sforms] (.-source c)
+               [thead & tmore :as tforms] (.-target c)
+               cost (.get real-cost c)
+               ^DiffContext context (.-context c)
+               prevsources (.-prevsources context)
+               prevtargets (.-prevtargets context)]
+           (swap! state-info update (System/identityHashCode c) update :attrib conj :popped)
+           (if (and (nil? shead) (nil? thead) (empty? prevsources) (empty? prevtargets))
+             c
+             (let [ssize (.get sizes shead)
+                   tsize (.get sizes thead)]
+               ;; if we can match subtrees, don't bother doing anything else
+               (if (and shead thead (= (.get hashes shead) (.get hashes thead)))
+                 (explore cost c smore tmore context (.-changes c))
+                 (do
+                   (if shead
+                     ;; addition/deletion costs an extra point so that we prefer removing entire lists
+                     (explore (inc (+ cost ssize)) c smore tforms context (conj (.-changes c) [shead :deleted]))
+                     ;; if we are at the end of the source seq, pop back out if we can
+                     (when (not= 0 (count prevsources))
+                       (explore cost c (peek prevsources) tforms
+                                (DiffContext. (pop prevsources) prevtargets) (.-changes c))))
 
-                  (if thead
-                    ;; addition
-                    (explore (inc (+ cost tsize)) c sremain (- tremain tsize) sforms tmore context (conj (.-changes c) [thead :added]))
-                    ;; pop back out
-                    (when (not= 0 (count prevtargets))
-                      (explore cost c sremain tremain sforms (peek prevtargets)
-                               (DiffContext. prevsources (pop prevtargets)) (.-changes c))))
+                   (if thead
+                     ;; addition
+                     (explore (inc (+ cost tsize)) c sforms tmore context (conj (.-changes c) [thead :added]))
+                     ;; pop back out
+                     (when (not= 0 (count prevtargets))
+                       (explore cost c sforms (peek prevtargets)
+                                (DiffContext. prevsources (pop prevtargets)) (.-changes c))))
 
-                  ;; going into matching collections is not costless, again to prefer deleting entire lists
-                  (when (and (tree/branch? shead) (tree/branch? thead) (= (:delim shead) (:delim thead)))
-                    (explore (inc cost) c sremain tremain (tree/->children shead) (tree/->children thead)
-                             (DiffContext. (conj prevsources smore) (conj prevtargets tmore)) (.-changes c)))
+                   ;; going into matching collections is not costless, again to prefer deleting entire lists
+                   (when (and (tree/branch? shead) (tree/branch? thead) (= (:delim shead) (:delim thead)))
+                     (explore (inc cost) c (tree/->children shead) (tree/->children thead)
+                              (DiffContext. (conj prevsources smore) (conj prevtargets tmore)) (.-changes c)))
 
-                  ;; going into source node corresponds to stripping a pair of parens
-                  (when (tree/branch? shead)
-                    (explore (+ 2 cost) c sremain tremain (tree/->children shead) tforms
-                             (DiffContext. (conj prevsources smore) prevtargets) (conj (.-changes c) [shead :parens-deleted])))
+                   ;; going into source node corresponds to stripping a pair of parens
+                   (when (tree/branch? shead)
+                     (explore (+ 2 cost) c (tree/->children shead) tforms
+                              (DiffContext. (conj prevsources smore) prevtargets) (conj (.-changes c) [shead :parens-deleted])))
 
-                  ;; going into target node is wrapping with a new set of parens
-                  (when (and (tree/branch? thead))
-                    (explore (+ 2 cost) c sremain tremain sforms (tree/->children thead)
-                             (DiffContext. prevsources (conj prevtargets tmore)) (conj (.-changes c) [thead :parens-added])))))
-              (recur))))))))
+                   ;; going into target node is wrapping with a new set of parens
+                   (when (and (tree/branch? thead))
+                     (explore (+ 2 cost) c sforms (tree/->children thead)
+                              (DiffContext. prevsources (conj prevtargets tmore)) (conj (.-changes c) [thead :parens-added])))))
+               (recur)))))))))
 
 (defn diffstate->annotations
   [^DiffState dst]

--- a/src/autochrome/diff.clj
+++ b/src/autochrome/diff.clj
@@ -53,10 +53,6 @@
     (let [^DiffState that that-obj]
       (- (.-cost this) (.-cost that)))))
 
-(defn get-cost
-  [^DiffState ds]
-  (.-cost ds))
-
 (defn get-target
   [^DiffState ds]
   (.-origtarget ds))
@@ -65,8 +61,6 @@
 (def explored-states (atom []))
 (def state-info (atom {}))
 (def nprocessed (atom 0))
-
-(def ^:dynamic *max-cost* Long/MAX_VALUE)
 
 (defn diff-prep
   [sources targets]

--- a/src/autochrome/diff.clj
+++ b/src/autochrome/diff.clj
@@ -81,11 +81,8 @@
          explore (fn [ncost ^DiffState predstate nsource ntarget nctx changes]
                    (let [ds (DiffState. ncost nsource ntarget nctx changes (.-origtarget predstate))
                          prev-cost (.get real-cost ds)]
-                     (swap! explored-states conj ds)
                      (swap! state-info update (System/identityHashCode ds) assoc :pred (System/identityHashCode predstate))
                      (when (and (or (nil? prev-cost) (< ncost prev-cost)))
-                       (swap! state-info update (System/identityHashCode ds) update :attrib conj
-                              (if (nil? prev-cost) :best :better))
                        (.put real-cost ds ncost)
                        (.offer pq ds))))]
      (reset! explored-states [])
@@ -97,6 +94,7 @@
      (loop []
        (when-let [^DiffState c (.poll pq)]
          (swap! nprocessed inc)
+         (swap! explored-states conj c)
          (let [[shead & smore :as sforms] (.-source c)
                [thead & tmore :as tforms] (.-target c)
                cost (.get real-cost c)

--- a/src/autochrome/diff.clj
+++ b/src/autochrome/diff.clj
@@ -64,7 +64,7 @@
 ;; for difflog
 (def explored-states (atom []))
 (def state-info (atom {}))
-(def npopped (atom 0))
+(def nprocessed (atom 0))
 
 (def ^:dynamic *max-cost* Long/MAX_VALUE)
 
@@ -96,14 +96,13 @@
                        (.offer pq ds))))]
      (reset! explored-states [])
      (reset! state-info {})
-     (reset! npopped 0)
      (doseq [t targets
              :let [start-state (DiffState. 0 (list source) (list t) (DiffContext. [] []) [] t)]]
        (.offer pq start-state)
        (.put real-cost start-state 0))
      (loop []
        (when-let [^DiffState c (.poll pq)]
-         (swap! npopped inc)
+         (swap! nprocessed inc)
          (let [[shead & smore :as sforms] (.-source c)
                [thead & tmore :as tforms] (.-target c)
                cost (.get real-cost c)

--- a/src/autochrome/difflog.clj
+++ b/src/autochrome/difflog.clj
@@ -7,7 +7,6 @@
             [om.dom :as dom]))
 
 (defn diff2
-  "a and b should be root nodes but only one form is expected"
   [ann a b]
   (comp/panes
    {}
@@ -20,10 +19,8 @@
 
 (defn diff-log
   [aroot broots]
-  (reset! diff/nprocessed 0)
-  (let [goalstate (time (diff/dforms aroot broots))
+  (let [goalstate (diff/dforms aroot broots)
         maxdigits (count (str (count @diff/explored-states)))]
-    (println 'explored (count @diff/explored-states) 'states 'popped @diff/nprocessed)
     (for [index (range (count @diff/explored-states))
           :let [c (nth @diff/explored-states index)
                 idhc (System/identityHashCode c)
@@ -43,8 +40,8 @@
             ",+" (count (filter (comp #{:added :parens-added} second) (.-changes c)))
             " cost " (.-cost c)
             ;; "/" (- (.-cost c) (max (.-sremain c) (.-tremain c)))
-            " remain " (.-sremain c)
-            "/" (.-tremain c)
+            ; " remain " (.-sremain c)
+            ;"/" (.-tremain c)
             (if (nil? shead) " (nil S)" "")
             (if (nil? thead) " (nil T)" ""))
            #_(dom/span {} " (" (Integer/toHexString idhc) " from "
@@ -59,8 +56,18 @@
          #_(comp/spacer))))))
 
 
-#_(write-difflog
-  "."
-  "difflog2"
-  (slurp "src/autochrome/tree.clj")
-  (slurp "src/autochrome/treecopy.clj"))
+(defn write-difflog
+  [title astr bstrs]
+  (let [a (parse/parse-one astr)
+        bs (map parse/parse-one bstrs)]
+    (spit (str title ".html")
+          (page/page
+            title
+            (comp/root {}
+                       (diff-log a bs))))))
+
+(comment
+  (write-difflog
+   "difflog2"
+   "[:a :b :c]"
+   ["[:a :b :c :d :e]"]))

--- a/src/autochrome/difflog.clj
+++ b/src/autochrome/difflog.clj
@@ -20,9 +20,10 @@
 
 (defn diff-log
   [aroot broots]
+  (reset! diff/nprocessed 0)
   (let [goalstate (time (diff/dforms aroot broots))
         maxdigits (count (str (count @diff/explored-states)))]
-    (println 'explored (count @diff/explored-states) 'states 'popped @diff/npopped)
+    (println 'explored (count @diff/explored-states) 'states 'popped @diff/nprocessed)
     (for [index (range (count @diff/explored-states))
           :let [c (nth @diff/explored-states index)
                 idhc (System/identityHashCode c)

--- a/src/autochrome/page.clj
+++ b/src/autochrome/page.clj
@@ -1,17 +1,15 @@
 (ns autochrome.page
   (:require [autochrome.annotation :as annotation]
+            [autochrome.align :as align]
             [autochrome.common :as clj-common]
             [autochrome.components :as comp]
-            [autochrome.diff :as diff]
             [autochrome.github :as github]
             [autochrome.parse :as parse]
             [autochrome.styles :as styles]
-            [clojure.string :as string]
             [hiccup.page :as hp]
             [om.dom :as dom])
   (:import [java.security MessageDigest]
-           [javax.xml.bind DatatypeConverter]
-           [java.util IdentityHashMap]))
+           [javax.xml.bind DatatypeConverter]))
 
 (defn clojure-file?
   [s]
@@ -79,71 +77,19 @@
         (assoc :linkbase linkbase)
         render-top-level-form)))
 
-(defn top-level-text
-  [{:keys [contents]}]
-  (string/join
-   " "
-   (keep identity
-         (for [f contents]
-           (case (:type f)
-             :quote (parse/render f)
-             (:keyword :symbol) (:text f)
-             nil)))))
-
 (defn two-file-diff
   [linkbase old new]
-  (let [aforms (:contents (:root old))
-        bforms (:contents (:root new))
-        adefs (group-by top-level-text aforms)
-        bdefs (group-by top-level-text bforms)
-        common? (set (filter #(= 1 (count (adefs %)) (count (bdefs %))) (keys bdefs)))
-        matched-pairs
-        (for [b bforms
-              :when (common? (top-level-text b))
-              :let [matched (first (get adefs (top-level-text b)))]]
-          {:line (:start-line b)
-           :forms [matched b]})
-        unmatched-pairs
-        (loop [result []
-               [a :as as] aforms
-               [b :as bs] bforms]
-          (cond
-            (and (empty? as) (empty? bs))
-            result
-
-            (common? (top-level-text a))
-            (recur result (next as) bs)
-
-            (common? (top-level-text b))
-            (recur result as (next bs))
-
-            :else
-            (recur
-             (conj result {:line (or (:start-line b) (:start-line a))
-                           :forms [a b]})
-             (next as)
-             (next bs))))
-        ann2
-        (fn [a b]
-          (cond
-            (nil? a) (doto (IdentityHashMap.) (.put b :added))
-            (nil? b) (doto (IdentityHashMap.) (.put a :deleted))
-            :else (diff/diff-forms a b)))
-        diff2
-        (fn [a b]
-          (let [ann (ann2 a b)]
-            (when-not (.isEmpty ann)
-              (comp/panes
-               {}
-               (some->> a list (diff-pane (str linkbase (md5sum (:path old)) "L") ann))
-               (some->> b list (diff-pane (str linkbase (md5sum (:path new)) "R") ann))))))]
-    (->> (concat matched-pairs unmatched-pairs)
-         (sort-by :line)
-         (keep
-          (fn [{[a b] :forms}]
-            (let [empty-form {:type :root :contents []}]
-              (diff2 a b))))
-         (interpose (comp/spacer)))))
+  (->> (align/get-diffs (:contents (:root old)) (:contents (:root new)))
+       (sort-by
+         (fn [[s t _]]
+           (or (:start-line t) (:start-line s))))
+       (map
+         (fn [[s t ann]]
+           (comp/panes
+             {}
+             (some->> s list (diff-pane (str linkbase (md5sum (:path old)) "L") ann))
+             (some->> t list (diff-pane (str linkbase (md5sum (:path new)) "R") ann)))))
+       (interpose (comp/spacer))))
 
 (defn delete-everything
   [root]
@@ -155,7 +101,7 @@
   (comp/root {} (diff-pane (str linkbase (md5sum path) lr) {} (:contents root))))
 
 (defn patch-heading
-  [{:keys [old-path old-text new-path new-text]}]
+  [{:keys [old-path new-path]}]
   (comp/heading
    (cond
      (= old-path "/dev/null") (str new-path " (new file)")
@@ -164,7 +110,7 @@
      :else new-path)))
 
 (defn clojure-diff
-  [linkbase {:keys [old-path old-text new-path new-text] :as patch}]
+  [linkbase {:keys [old-path old-text new-path new-text]}]
   (cond
     (= old-path "/dev/null")
     (one-file-diff linkbase new-path "R" (parse/parse new-text))
@@ -193,7 +139,7 @@
   (println (count changed-files) "changed files")
   (->> changed-files
        (mapcat
-        (fn [{:keys [old-path old-text new-path new-text] :as patch}]
+        (fn [{:keys [old-path new-path] :as patch}]
           [(patch-heading patch)
            (if (or (clojure-file? new-path)
                    (and (= "/dev/null" new-path)

--- a/src/autochrome/readme.clj
+++ b/src/autochrome/readme.clj
@@ -411,7 +411,6 @@
            "If you split a 100-line function into two pieces and also make a bunch of changes, it might take like 30 seconds to diff.  "
            "That's not great, but you'll probably spend more than 30 seconds looking at a diff like that anyway."))))))
 
-(do
+(clojure.core/comment
   (gen-readme)
-  ;(difflog/write-difflog "difflog" (first example1) [(second example1)])
-  )
+  (difflog/write-difflog "difflog" (first example1) [(second example1)]))

--- a/src/autochrome/readme.clj
+++ b/src/autochrome/readme.clj
@@ -22,7 +22,7 @@
    [:p {:text-indent "2em"}]
    [:.diffpane {:width "unset"}]
    [:.text {:font-family "sans-serif"}]
-   [:.textcontainer {:width "67%"
+   [:.textcontainer {:width "57%"
                      :font-size "18px"}]
    [:.title {:font-size "32px"}]
    [:.sectiontitle {:font-size "24px"
@@ -87,9 +87,9 @@
 
 (defn diff2
   [atext btext]
-  (let [aroot (parse/parse atext)
-        broot (parse/parse btext)]
-    (difflog/diff2 (diff/diff-forms aroot broot) aroot broot)))
+  (let [aroot (parse/parse-one atext)
+        broot (parse/parse-one btext)]
+    (difflog/diff2 (diff/diff-forms aroot [broot]) aroot broot)))
 
 (defn side-caption
   [& body]
@@ -206,19 +206,16 @@
           "It takes the form of a command-line tool which generates diffs as static HTML: ")
        (term
         "$ lein run " (dom/i {} "owner") " " (dom/i {} "repo") " " (dom/i {} "num") " -o diff.html"
-        (comment "        # write a diff for a GitHub pull request")
+        (comment "        # write a diff for a github pull request")
 
         "\n$ lein run --token user:123abc "(dom/i {} "owner") " " (dom/i {} "repo") " " (dom/i {} "num")
         (comment " # use supplied auth token for github api")
 
-        "\n$ lein run ... --open"
-        (comment "                         # try to open the diff in a browser")
+        "\n$ lein run --git-dir " (dom/i {} "/your/repo/ ") (dom/i {} "old-tree") " " (dom/i {} "new-tree")
+        (comment "  # like git diff, using specified repo")
 
-        "\n$ lein uberjar"
-        (comment "                          # create a standalone jar in target/ directory")
-
-        "\n$ java -jar autochrome.jar " (dom/i {} "old-tree") " " (dom/i {} "new-tree")
-        (comment "  # run like git diff from your repo"))
+        "\n$ lein run --open ..."
+        (comment "                         # try to open the diff in a browser"))
        (p "If generated from GitHub, the line numbers in Clojure diffs link back to the PR.  "
           "Bold symbols link to documentation."))
       (section
@@ -247,13 +244,14 @@
           (dom/a {:href "http://thume.ca/2017/06/17/tree-diffing/"}
                  "Tristan Hume's article about tree diffing")
           ", I was inspired to give it a shot myself using the same A* pathfinding technique he described.  "
-          "In order to apply A* to the problem of tree diffing, you need to extend the concepts "
-          "of location, cost, distance, and adjacency to tree diffs.  Location is clearly needed to know where you are, "
-          "but in addition they need to be comparable, so you know not to bother when you already have a better "
+          "I ended up ditching A* for plain old Dijkstra's algorithm however - "
+          (dom/a {:href "#alignment"} "more on that later") ".  "
+          "Either way, in order to frame tree diffing as a pathfinding problem, you need to extend the concepts "
+          "of location, cost, and adjacency to tree diffs.  Location is clearly needed to know where you are, "
+          "but in addition locations need to be comparable, so you know not to bother when you already have a better "
           "path to the same place.  "
           "Cost is what makes some paths preferred over others.  For pathfinding on a road network, this would be "
-          "the total distance traveled along the roads used.  By 'distance' I really mean the A* heuristic, "
-          "which in the case of roads might be the straight-line distance to the destination.  "
+          "the total distance traveled along the roads used. "
           "Adjacency is what states are reachable from a particular state.  For roads you might say that intersections are "
           "the nodes and adjacency means there is a road connecting them.  "
           "In autochrome:"
@@ -267,9 +265,6 @@
                           "Subtree size is 1 for empty collections, character count for text nodes, and sum size of children for branch nodes.  "
                           "The number of subtrees changed is included in the cost so that the algorithm prefers deleting/adding entire"
                           "lists, rather than all their elements (since they have the same cost otherwise).")
-                  (dom/li {} "Distance is the maximum of the \"remaining\" tree sizes for the source and target tree.  "
-                          "Whenever a subtree is accounted for by being added, deleted, or matched with an identical subtree, "
-                          "its size is subtracted from the remaining size.")
                   (dom/li {} "Adjacency is a bit complicated:"
                           (dom/ul {}
                                   (dom/li {} "When the source and target cursors are over identical subtrees, we always advance both cursors.")
@@ -302,40 +297,32 @@
      (section
       "Worked Example"
       (p "I don't know about you, but I'm not the type who can absorb the essence of a complicated algorithm from a wall of text as seen above.  "
-         "So let's look at a detailed log of all the states we popped from our A* priority queue while generating the example diff at the top of this page.  "
-         "The states are numbered in the order in which they were explored, however I will only show the goal state and its predecessors,  "
+         "So let's look at a detailed log of the states we popped from our priority queue while generating the example diff at the top of this page.  "
+         "The states are numbered in the order in which they were processed.  We will look at the goal state and each of its predecessors,  "
          "starting from the initial state.")))
-    (let [a (parse/parse (first example1))
-          b (parse/parse (second example1))
-          logs (vec (difflog/diff-log a b))]
+    (let [a (parse/parse-one (first example1))
+          b (parse/parse-one (second example1))
+          logs (vec (difflog/diff-log a [b]))]
       (dom/div {:className "examplesection"}
                (loginset (first logs)
                          (side-caption "The source cursor is blue, and the target cursor is purple.  "
-                                       "As you can see, we start with each cursor over its entire subtree.  "
-                                       "The header at the top shows information about the diff state:"
-                                       (dom/ul {}
-                                               (dom/li {} (fixed "-0,+0") "  is the number of deletions and additions")
-                                               (dom/li {} (fixed "cost 0/-92") "  is the heuristic cost / real cost.  Meaningless for start node.")
-                                               (dom/li {} (fixed "remain 90/92") "  is the remaining cost of the source and target trees."))
-                                       "Note that real cost = heuristic cost - max(source remaining, target remaining).  "
-                                       "By heuristic cost, I mean the estimated total distance from the start to the goal, used as the key in the priority queue, "
-                                       "or " (dom/i {} "g(n) + h(n)") " in "
-                                       (dom/a {:href "https://en.wikipedia.org/wiki/A*_search_algorithm#Description"}
-                                              "typical A* notation.  ")))
+                                       "As you can see, we start with each cursor over its entire subtree.  "))
                (loginset
-                (nth logs 3)
+                (nth logs 1)
                 (side-caption "After we enter the main loop and pop the start state, we can start exploring.  "
-                              "In this state we have matched the parentheses and descended into the defn body. "))
+                              "In this state we have matched the parentheses and descended into the defn body. "
+                              "Going into lists has cost 1, so that deleting an entire list "
+                              "is cheaper than deleting each of its elements."))
                (loginset
-                (nth logs 6)
+                (nth logs 2)
                 (side-caption "We matched " (fixed "defn") " with " (fixed "defn") " and advanced both cursors. "
                               "Now we can now match " (fixed "example") " with " (fixed "example") "."))
                (loginset
-                (nth logs 7)
+                (nth logs 3)
                 (side-caption "Since matching is done with subtree hashes, we can match " (fixed "[x]")
                               " without going into the vector at all."))
                (loginset
-                (nth logs 8)
+                (nth logs 4)
                 (side-caption
                  "Now we have our first mismatch.  We have a few options here:"
                  (dom/ol {}
@@ -345,39 +332,86 @@
                          (dom/li {} "Go into blue subtree only")
                          (dom/li {} "Go into purple subtree only"))))
                (loginset
-                (nth logs 13)
+                (nth logs 8)
                 (side-caption "We explore all of those options, but eventually we choose the last.  "
                               "Since we moved the target cursor into a list while the source cursor stayed put, "
                               "it follows that if we finish diffing, the parens which create that extra list must have been added, "
-                              "so we can go ahead and paint them green."))
+                              "so we can go ahead and paint them green, and add 2 to the cost."))
                (loginset
-                (nth logs 20)
-                (side-caption "Add the " (fixed "->") "."))
+                (nth logs 11)
+                (side-caption "Add the " (fixed "->") ".  It has size 2, but the new cost is 6.  This is because "
+                              "each addition/deletion costs 1 extra point, so that "
+                              "minimal diffs are cheaper than equivalent diffs with more changes. "))
                (loginset
-                (nth logs 25)
-                (side-caption "Now we enqueue this state, #25, where we delete " (fixed "(println \"hello\")") ".  "
-                              "Since it's a relatively large subtree, deleting it has a high cost, "
-                              "so we actually spend a lot of time going through other states before it is finally popped."))
+                (nth logs 60)
+                (side-caption " Delete " (fixed "(println \"hello\")") ".  Note that this is state #60 while the previous "
+                              "state was #11 - we explored a whole bunch of dead-end states in between.  "
+                              "This is because the deletion has a relatively high cost, so Dijkstra prefers to do "
+                              "low- or no-cost movement before eventually getting around to this state."))
                (loginset
-                (nth logs 115)
-                (side-caption "But once we do pop it, we can match the identical maps under the cursors.  "
-                              "Since the map was the last element in the source defn body, the source cursor has reached the "
-                              "end of its list, so there is nothing to highlight in blue and it says "
-                              (fixed "(nil S)") " in the header."))
+                (nth logs 63)
+                (side-caption "Match the identical maps and advance each cursor.  "
+                              "Since the map was the last element in the source defn body, the "
+                              "source cursor has reached the end of its list, so there is nothing to highlight "
+                              "in blue and it says " (fixed "(nil S)") " in the header."))
                (loginset
-                (nth logs 122)
-                (side-caption "Add " (fixed "(assoc :twice (+ x x))") ".  This is the last element in the current "
-                              "target sequence, so now we have " (fixed "(nil S)") " and " (fixed "(nil T)") ".  "
-                              "At this point the source stack is " (fixed "[nil]") " and the target stack is " (fixed "[nil nil]") ", "
-                              "so we have to do two steps where we pop both and then pop target only, but the order doesn't matter."))
+                (nth logs 65)
+                (side-caption "It may look like nothing happened, but we popped out of the left subtree only here.  "
+                              "This is an example of how movement operations get processed before any additions/deletions.  "
+                              "It's completely free to explore here, so we might as well!"))
                (loginset
-                (nth logs 125)
-                (side-caption  "In fact, since the stacks are not shown, we can't even tell which order was taken.  "
-                               "In either case, from here we do whichever pop operation we didn't just do. "))
+                 (nth logs 197)
+                 (side-caption "Add " (fixed "(assoc :twice (+ x x))") ".  Another costly change means another big gap in state number.  "
+                               "That was the last element in the "
+                               "target sequence, so now we have " (fixed "(nil S)") " and " (fixed "(nil T)") ".  "))
                (loginset
-                (nth logs 126)
-                (side-caption "Now we have " (fixed "(nil S)") " and " (fixed "(nil T)") ", "
-                              "and both stacks will be empty, so we are done!")))))))
+                (nth logs 200)
+                (side-caption  "Pop out of the " (fixed "(-> ...)") "."))
+               (loginset
+                (nth logs 203)
+                (side-caption "Pop out of the target defn body.  "
+                              "Now that we have popped all the way out of both forms, "
+                              "both stacks are empty and there are no more forms to diff,  so we are done!"))))
+    (dom/div
+      {:className "textcontainer"
+       :style {:margin "auto"}
+       :id "alignment"}
+      (section
+        "Alignment"
+        (p "I had originally implemented the diff algorithm as A*, which was a lot better at finding diffs with fewer explored states.  "
+           "What made me decide to switch to plain Dijkstra's algorithm was the problem of alignment.  When multiple forms in a file "
+           "are changed, inserted, renamed or deleted, how do you figure out which pairs to diff?"
+           "A* works great when you know both the source and the target forms, but this proved difficult in practice.  ")
+        (p "My first idea was to simply diff the entire source file with the entire target file, basically treating each file "
+           "as if it had [] surrounding the entire thing.  This led to a lot of weird diffs; for example when you deleted "
+           "something and inserted something else in its place, the diff would show how to transform the deleted thing "
+           "into the new thing, which was confusing.  "
+           "Top-level forms are the basic unit of clojure code, so diffs which span them are unnatural and hard to read.  "
+           "When the change-of-nesting support was implemented, things really got out of hand.")
+        (p "Something had to be done.  My next idea was to basically hack it by trying to match forms by their top-level text, "
+           "for example 'defn somefn' or 'defmethod foo :dval'.  This has a lot of obvious problems, including docstrings, but "
+           "especially renames.  It worked better than I expected but the problem was still not solved.")
+        (p "The solution I came up with is to diff each target form in the old file against " (dom/i {} "all") " forms in the new file.  "
+           "This is done by adding N start states to the priority queue, instead of only one, where N is the number of candidate target forms. "
+           "Since A* really only makes sense in the context of single-source shortest paths, I decided to just switch to Dijkstra's algorithm,  "
+           "which can deal just fine with multiple origins.  Since the diffs are processed in order of increasing cost, we know that "
+           "the first complete diff we see will be the lowest-cost-possible diff of the source form with any of the target forms.  "
+           "So we trade away single-target diff performance, but in return we get the guaranteed optimal solution to the alignment problem. ")
+        (p "Doing diffs this way is technically quadratic, since in the worst case it requires every source form to be diffed against every "
+           "target form, but there are a couple tricks that can be used to make it more palatable.  "
+           "Most of the time, the majority of the forms in a file will be unchanged, so we can just hash everything first and match those "
+           "right away.  That means the runtime is only quadratic with respect to the number of changed forms, which is better.  "
+           "Second, each target form can only be matched to one source form, so we if we have to diff the first source against N targets, "
+           "we only need to diff the second against N-1, and so on.  Still quadratic but oh well, parsing is usually slower anyway.  "
+           "Finally, in each list of candidate targets we always include nil, representing the cost of deleting the entire source form.  "
+           "This means no states more expensive than that are considered, which kind of controls the number of states we need to explore.")
+        (p "There are a couple of slow cases, but for the most part I think the gains are worth the switch to Dijkstra.  "
+           "Probably the slowest type of change to diff is splitting a very large form into two or more smaller forms, since we will spend "
+           "a huge amount of time trying to figure out which smaller form is most similar to the original large form.  For example, "
+           "If you split a 100-line function into two pieces and also make a bunch of changes, it might take like 30 seconds to diff.  "
+           "That's not great, but you'll probably spend more than 30 seconds looking at a diff like that anyway."))))))
 
-(clojure.core/comment
-  (gen-readme))
+(do
+  (gen-readme)
+  ;(difflog/write-difflog "difflog" (first example1) [(second example1)])
+  )

--- a/src/autochrome/tree.clj
+++ b/src/autochrome/tree.clj
@@ -48,7 +48,9 @@
                  (if (= :coll (:type form))
                    ;; empty collection
                    (.hashCode (:delim form))
-                   (throw (ex-info "unhashable" {:form form}))))
+                   (if (nil? form)
+                     0
+                     (throw (ex-info "unhashable" {:form form})))))
                (let [parent-hash (volatile! 0)]
                  (loop [i 0
                         [c & cs] children]

--- a/src/autochrome/tree.clj
+++ b/src/autochrome/tree.clj
@@ -51,7 +51,7 @@
                    (if (nil? form)
                      0
                      (throw (ex-info "unhashable" {:form form})))))
-               (let [parent-hash (volatile! 0)]
+               (let [parent-hash (volatile! 0x1a814d0)]
                  (loop [i 0
                         [c & cs] children]
                    (when c


### PR DESCRIPTION
- ditch A* for plain old Dijkstra
- this allows us to effectively diff a single source against a _list_ of targets
- Dijkstra ensures we get the best diff first
- We can always include the empty form in the list of targets so we never try any diffs more expensive than simply deleting the source

The point of this is so that we can leverage the diff algorithm to do alignment for us.  In other words, for each source form we can find the target form against which it has a minimal diff.  So we do the right thing for moves, renames, whatever.  

It's technically quadratic to do it this way but in practice it's not that bad, since we can do a linear pass first to get all of the identical forms.  That makes it quadratic only with respect to the number of changed forms which is better.  Also, we can stop diffing when there are no more unmatched source or target forms.  Since we diff a single source against multiple targets, that early termination means that whole-form deletions are basically free, while additions sort of suck since we will end up diffing every unmatched source form against each newly-added target form.  Doing it the other way around might be better since additions are probably more common than deletions.