### PR TITLE
Fix java 9 compatibility by adding javax.xml.bind module as a dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,9 @@
                  [cheshire "5.8.0"]
                  [clj-http "3.7.0"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [com.climate/claypoole "1.1.4"]]
+                 [com.climate/claypoole "1.1.4"]
+                 ;; explicit dependency on jaxb-api for java 9 compatibility
+                 [javax.xml.bind/jaxb-api "2.3.0"]]
   :main autochrome.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
Fixes https://github.com/ladderlife/autochrome/issues/11.